### PR TITLE
URL encoding changes + Other customizations

### DIFF
--- a/lib/payuindia.rb
+++ b/lib/payuindia.rb
@@ -9,8 +9,12 @@ module PayuIndia
   self.test_url = 'https://test.payu.in/_payment.php'
   self.production_url = 'https://secure.payu.in/_payment.php'
 
-  def self.service_url
-    defined?(Rails) && Rails.env == 'production' ? self.production_url : self.test_url
+  def self.service_url force_production = false
+    unless force_production
+      defined?(Rails) && Rails.env == 'production' ? self.production_url : self.test_url
+    else
+      self.production_url
+    end
   end
 
   def self.notification(post, options = {})

--- a/lib/payuindia.rb
+++ b/lib/payuindia.rb
@@ -10,12 +10,8 @@ module PayuIndia
   self.test_url = 'https://test.payu.in/_payment.php'
   self.production_url = 'https://secure.payu.in/_payment.php'
 
-  def self.service_url force_production = false
-    unless force_production
-      defined?(Rails) && Rails.env == 'production' ? self.production_url : self.test_url
-    else
-      self.production_url
-    end
+  def self.service_url
+    defined?(Rails) && Rails.env == 'production' ? self.production_url : self.test_url
   end
 
   def self.notification(post, options = {})

--- a/lib/payuindia.rb
+++ b/lib/payuindia.rb
@@ -40,7 +40,7 @@ module PayuIndia
 
     def form_fields
       sanitize_fields
-      @options.merge(:hash => generate_checksum)
+      @options.merge(:hash => generate_checksum, :key => @key)
     end
 
     def generate_checksum

--- a/lib/payuindia.rb
+++ b/lib/payuindia.rb
@@ -27,7 +27,7 @@ module PayuIndia
   end
 
   def self.checksum(merchant_id, secret_key, payload_items )
-    url_encoded_payload_items = payload_items.map{|str| CGI.escape(str)}
+    url_encoded_payload_items = payload_items.map{|str| CGI.escape(str.to_s)}
     Digest::SHA512.hexdigest([merchant_id, *url_encoded_payload_items, secret_key].join("|"))
   end
 

--- a/lib/payuindia.rb
+++ b/lib/payuindia.rb
@@ -1,3 +1,4 @@
+require "cgi"
 require "payuindia/version"
 require 'payuindia/action_view_helper'
 ActionView::Base.send(:include, PayuIndia::ActionViewHelper)
@@ -26,7 +27,8 @@ module PayuIndia
   end
 
   def self.checksum(merchant_id, secret_key, payload_items )
-    Digest::SHA512.hexdigest([merchant_id, *payload_items, secret_key].join("|"))
+    url_encoded_payload_items = payload_items.map{|str| CGI.escape(str)}
+    Digest::SHA512.hexdigest([merchant_id, *url_encoded_payload_items, secret_key].join("|"))
   end
 
   class Helper

--- a/lib/payuindia/action_view_helper.rb
+++ b/lib/payuindia/action_view_helper.rb
@@ -18,16 +18,18 @@ module PayuIndia #:nodoc:
     #       :furl => 'http://localhost:3000/payu_callback',
     #       :html => { :id => 'payment-form' } %>
 
-    def payment_form_for_payu(key, salt, options = {}, btn_html = nil)
-      if !options.is_a?(Hash) || !key.is_a?(String) || !salt.is_a?(String) || (btn_html != nil && !btn_html.is_a?(String))
-        concat("Something Wrong! params order -> key (String), salt (String), options (optional Hash), btn_html(optional String) ")
+    def payment_form_for_payu(key, salt, options = {})
+      if !options.is_a?(Hash) || !key.is_a?(String) || !salt.is_a?(String)
+        concat("Something Wrong! params order -> key (String), salt (String), options (Hash) ")
         nil
       else
         form_options = options.delete(:html) || {}
+        btn_text = options.delete(:btn_text) || "Pay with PayU"
+        force_production = options.delete(:force_production)
         service = PayuIndia::Helper.new(key, salt, options)
         result = []
 
-        result << form_tag(PayuIndia.service_url, form_options.merge(:method => :post))
+        result << form_tag(PayuIndia.service_url(force_production), form_options.merge(:method => :post))
 
         result << hidden_field_tag('key', key)
 
@@ -35,8 +37,8 @@ module PayuIndia #:nodoc:
           result << hidden_field_tag(field, value)
         end
 
-        result << (btn_html ? btn_html : '<input type=submit value=" Pay with PayU ">')
-        result << '</form>'
+        result << "<input type=\"submit\" value=\"#{btn_text}\">"
+        result << "</form>"
         result= result.join("\n")
 
         concat(result.respond_to?(:html_safe) ? result.html_safe : result)

--- a/lib/payuindia/action_view_helper.rb
+++ b/lib/payuindia/action_view_helper.rb
@@ -19,7 +19,7 @@ module PayuIndia #:nodoc:
     #       :html => { :id => 'payment-form' } %>
 
     def payment_form_for_payu(key, salt, options = {}, btn_html = nil)
-      if !options.is_a?(Hash) || !key.is_a?(String) || !salt.is_a?(String) || (btn_html != nil && btn_html.is_a?(String))
+      if !options.is_a?(Hash) || !key.is_a?(String) || !salt.is_a?(String) || (btn_html != nil && !btn_html.is_a?(String))
         concat("Something Wrong! params order -> key (String), salt (String), options (optional Hash), btn_html(optional String) ")
         nil
       else

--- a/lib/payuindia/action_view_helper.rb
+++ b/lib/payuindia/action_view_helper.rb
@@ -18,9 +18,9 @@ module PayuIndia #:nodoc:
     #       :furl => 'http://localhost:3000/payu_callback',
     #       :html => { :id => 'payment-form' } %>
 
-    def payment_form_for_payu(key, salt, options = {})
-      if !options.is_a?(Hash) || !key.is_a?(String) || !salt.is_a?(String)
-        concat("Something Wrong! params order -> key (String), salt (String), options (Hash) ")
+    def payment_form_for_payu(key, salt, options = {}, btn_html = nil)
+      if !options.is_a?(Hash) || !key.is_a?(String) || !salt.is_a?(String) || (btn_html != nil && btn_html.is_a?(String))
+        concat("Something Wrong! params order -> key (String), salt (String), options (optional Hash), btn_html(optional String) ")
         nil
       else
         form_options = options.delete(:html) || {}
@@ -35,7 +35,7 @@ module PayuIndia #:nodoc:
           result << hidden_field_tag(field, value)
         end
 
-        result << '<input type=submit value=" Pay with PayU ">'
+        result << (btn_html ? btn_html : '<input type=submit value=" Pay with PayU ">')
         result << '</form>'
         result= result.join("\n")
 

--- a/lib/payuindia/action_view_helper.rb
+++ b/lib/payuindia/action_view_helper.rb
@@ -25,7 +25,7 @@ module PayuIndia #:nodoc:
       else
         form_options = options.delete(:html) || {}
         btn_text = options.delete(:btn_text) || "Pay with PayU"
-        force_production = options.delete(:force_production)
+        force_production = options.delete(:force_production) || false
         service = PayuIndia::Helper.new(key, salt, options)
         result = []
 

--- a/lib/payuindia/action_view_helper.rb
+++ b/lib/payuindia/action_view_helper.rb
@@ -25,11 +25,10 @@ module PayuIndia #:nodoc:
       else
         form_options = options.delete(:html) || {}
         btn_text = options.delete(:btn_text) || "Pay with PayU"
-        force_production = options.delete(:force_production) || false
         service = PayuIndia::Helper.new(key, salt, options)
         result = []
 
-        result << form_tag(PayuIndia.service_url(force_production), form_options.merge(:method => :post))
+        result << form_tag(PayuIndia.service_url, form_options.merge(:method => :post))
 
         service.form_fields.each do |field, value|
           result << hidden_field_tag(field, value)

--- a/lib/payuindia/action_view_helper.rb
+++ b/lib/payuindia/action_view_helper.rb
@@ -31,8 +31,6 @@ module PayuIndia #:nodoc:
 
         result << form_tag(PayuIndia.service_url(force_production), form_options.merge(:method => :post))
 
-        result << hidden_field_tag('key', key)
-
         service.form_fields.each do |field, value|
           result << hidden_field_tag(field, value)
         end


### PR DESCRIPTION
* Issue fixed : Ruby SDK not doing URL encoding (application/x-www-form-urlencoded) for given params. But Android and iOS doing it. So checksum calculated from ruby SDK is not matching with checksum calculated by iOS and Andorid.
* Added feature to customizing the text in pay button
* `form_fields` method will return including `merchant_id (key)`.